### PR TITLE
Replace endChoice with end

### DIFF
--- a/docs/conditional-flow.md
+++ b/docs/conditional-flow.md
@@ -17,7 +17,7 @@ $flow = (new \Phlow\Model\WorkflowBuilder())
         ->callback(function () {
             print("Number provided was EQUAL OR GREATER than 100\n");
         })
-    ->endChoice()
+    ->end()
     ->end()
     ->getWorkflow();
 

--- a/src/Util/HashMap.php
+++ b/src/Util/HashMap.php
@@ -72,6 +72,6 @@ class HashMap
             throw new \UnderflowException();
         }
 
-        return isset($this->map[$this->getHash($key)]) ? $this->map[$this->getHash($key)]: null;
+        return $this->map[$this->getHash($key)];
     }
 }

--- a/tests/Workflow/WorkflowBuilderTest.php
+++ b/tests/Workflow/WorkflowBuilderTest.php
@@ -71,10 +71,10 @@ class WorkflowBuilderTest extends TestCase
                         ->script()
                     ->otherwise()
                         ->script()
-                ->endChoice()
+                ->end()
             ->otherwise()
                 ->script()
-            ->endChoice()
+            ->end()
             ->end();
 
         $workflow = $builder->getWorkflow();


### PR DESCRIPTION
There are currently two end method which could be combined into one. This could minimise the verbosity of ending a choice / workflow . The purpose of this PR is to replace endChoice with end