### PR TITLE
New method: endAll()

### DIFF
--- a/docs/conditional-flow.md
+++ b/docs/conditional-flow.md
@@ -17,8 +17,7 @@ $flow = (new \Phlow\Model\WorkflowBuilder())
         ->callback(function () {
             print("Number provided was EQUAL OR GREATER than 100\n");
         })
-    ->end()
-    ->end()
+    ->endAll()
     ->getWorkflow();
 
 $instance = new \Phlow\Engine\WorkflowInstance($flow, ['number' => 99]);

--- a/src/Model/WorkflowBuilder.php
+++ b/src/Model/WorkflowBuilder.php
@@ -130,10 +130,9 @@ class WorkflowBuilder
     /**
      * If more than one Gateways are still open, it will close the newly created
      * Otherwise, it creates an End event for this workflow.
-     * @param int $howMany
      * @return WorkflowBuilder
      */
-    public function end(int $howMany = 1): WorkflowBuilder
+    public function end(): WorkflowBuilder
     {
         if (!$this->unlinkedNodes->isEmpty()) {
             $this->processChoiceBranch();
@@ -147,7 +146,20 @@ class WorkflowBuilder
             $this->add(new EndEvent());
         }
 
-        return ($howMany > 1) ? $this->end($howMany - 1) : $this;
+        return $this;
+    }
+
+    /**
+     * Closes all the opened Gateways and it creates a new EndEvent
+     * @see WorkflowBuilder::end()
+     */
+    public function endAll(): WorkflowBuilder
+    {
+        while (!($this->nodes->peek() instanceof EndEvent)) {
+            $this->end();
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Model/WorkflowBuilder.php
+++ b/src/Model/WorkflowBuilder.php
@@ -130,18 +130,24 @@ class WorkflowBuilder
     /**
      * If more than one Gateways are still open, it will close the newly created
      * Otherwise, it creates an End event for this workflow.
+     * @param int $howMany
      * @return WorkflowBuilder
      */
-    public function end(): WorkflowBuilder
+    public function end(int $howMany = 1): WorkflowBuilder
     {
-        if ($this->unlinkedNodes->isEmpty()) {
-            $this->add(new EndEvent());
-        } else {
+        if (!$this->unlinkedNodes->isEmpty()) {
             $this->processChoiceBranch();
-            $this->linkNodesFor = $this->nodes->pop();
+            $this->linkNodesFor = !$this->nodes->isEmpty() ? $this->nodes->pop() : null;
         }
 
-        return $this;
+        // A new EndEvent must be created in the following cases
+        // * There are no more unlinked nodes i.e. no Gateway was used in this Workflow
+        // * There is only one Gateway pending which must be linked with an EndEvent
+        if (1 >= $this->unlinkedNodes->count()) {
+            $this->add(new EndEvent());
+        }
+
+        return ($howMany > 1) ? $this->end($howMany - 1) : $this;
     }
 
     /**

--- a/src/Util/HashMap.php
+++ b/src/Util/HashMap.php
@@ -7,7 +7,7 @@ class HashMap
     /**
      * @var array
      */
-    private $map;
+    private $map = [];
 
     /**
      * Calculate a unique identifier for the contained objects
@@ -73,5 +73,14 @@ class HashMap
         }
 
         return $this->map[$this->getHash($key)];
+    }
+
+    /**
+     * Count elements of this HashMap
+     * @return int
+     */
+    public function count(): int
+    {
+        return count($this->map);
     }
 }

--- a/tests/Workflow/WorkflowBuilderTest.php
+++ b/tests/Workflow/WorkflowBuilderTest.php
@@ -74,7 +74,7 @@ class WorkflowBuilderTest extends TestCase
                 ->end()
             ->otherwise()
                 ->script()
-            ->end(2);
+            ->endAll();
 
         $workflow = $builder->getWorkflow();
 

--- a/tests/Workflow/WorkflowBuilderTest.php
+++ b/tests/Workflow/WorkflowBuilderTest.php
@@ -74,8 +74,7 @@ class WorkflowBuilderTest extends TestCase
                 ->end()
             ->otherwise()
                 ->script()
-            ->end()
-            ->end();
+            ->end(2);
 
         $workflow = $builder->getWorkflow();
 


### PR DESCRIPTION
The suggestion is to minimise the verbosity when ending multiple opened Gateways and/or creating a  new EndEvent.

For instance, instead of writing 

```
    ->end()->end();
```

We could write 

```
    ->end(2);
```

Another option is the following:

```
    ->endAll()
```