### PR TITLE
Custom exceptions

### DIFF
--- a/src/Engine/InvalidStateException.php
+++ b/src/Engine/InvalidStateException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phlow\Engine;
+
+/**
+ * Class InvalidStateException
+ * Indicates that the execution has reached an invalid state and can not advance further.
+ * For instance an EndEvent has been already reached or the next Workflow Node is undefined.
+ * @package Phlow\Engine
+ */
+class InvalidStateException extends \RuntimeException
+{
+}

--- a/src/Engine/UndefinedHandlerException.php
+++ b/src/Engine/UndefinedHandlerException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Phlow\Engine;
+
+/**
+ * Class UndefinedHandlerException
+ * Indicates that no handler was found and execution can not advance further
+ * @package Phlow\Engine
+ */
+class UndefinedHandlerException extends \Exception
+{
+}

--- a/src/Engine/WorkflowInstance.php
+++ b/src/Engine/WorkflowInstance.php
@@ -76,7 +76,7 @@ class WorkflowInstance
     {
         $this->initNodes();
         if ($this->isCompleted()) {
-            throw new \RuntimeException("Workflow has been already completed.");
+            throw new InvalidStateException('Workflow execution has reached an End event and can not advance further.');
         }
 
         // Retrieve and execute the next node

--- a/src/Engine/WorkflowInstance.php
+++ b/src/Engine/WorkflowInstance.php
@@ -145,7 +145,7 @@ class WorkflowInstance
 
         $startEvents = $this->workflow->getAllByClass(StartEvent::class);
         if (empty($startEvents)) {
-            throw new \RuntimeException('Start event is missing');
+            throw new InvalidStateException('Start event is missing.');
         }
 
         $this->currentNode = $startEvents[0];
@@ -158,7 +158,7 @@ class WorkflowInstance
     {
         $errorEvents = $this->workflow->getAllByClass(ErrorEvent::class);
         if (empty($errorEvents)) {
-            throw new \RuntimeException('Error events are missing');
+            throw new InvalidStateException('Error events are missing');
         }
 
         $errorEventsMap = [];
@@ -198,6 +198,6 @@ class WorkflowInstance
             return $this->currentNode;
         }
 
-        throw new \RuntimeException("Execution has not been initiated for this Workflow.");
+        throw new InvalidStateException('Execution has not been initiated for this Workflow.');
     }
 }

--- a/src/Engine/WorkflowInstance.php
+++ b/src/Engine/WorkflowInstance.php
@@ -112,6 +112,7 @@ class WorkflowInstance
      * Handles a raised exception by moving the flow to an error event
      * If no error handling was configured, another Exception will be thrown halting the execution
      * @param \Exception $exception
+     * @throws UndefinedHandlerException
      */
     private function handleException(\Exception $exception): void
     {
@@ -128,7 +129,7 @@ class WorkflowInstance
             $exceptionClass = get_parent_class($exceptionClass);
         }
 
-        throw new \RuntimeException(
+        throw new UndefinedHandlerException(
             sprintf("The exception %s was thrown but no Error Event was found", get_class($exception))
         );
     }

--- a/src/Handler/ConditionalConnectionHandler.php
+++ b/src/Handler/ConditionalConnectionHandler.php
@@ -36,7 +36,7 @@ class ConditionalConnectionHandler implements Handler
             }
         }
 
-        throw new \RuntimeException("No condition was matched. Unable to calculate the next node.");
+        throw new UnmatchedConditionException('No condition was matched');
     }
 
 

--- a/src/Handler/SingleConnectionHandler.php
+++ b/src/Handler/SingleConnectionHandler.php
@@ -24,7 +24,7 @@ class SingleConnectionHandler implements Handler
     {
         $connections = $workflowNode->getOutgoingConnections();
         if (empty($connections)) {
-            throw new \RuntimeException("No connections found.");
+            throw new UnmatchedConditionException('No condition was matched');
         }
 
         /** @var WorkflowConnection $connection */

--- a/src/Handler/UnmatchedConditionException.php
+++ b/src/Handler/UnmatchedConditionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Phlow\Handler;
+
+class UnmatchedConditionException extends \RuntimeException
+{
+}

--- a/src/Model/ExceptionHandlerTrait.php
+++ b/src/Model/ExceptionHandlerTrait.php
@@ -29,7 +29,7 @@ trait ExceptionHandlerTrait
             return $this->exceptionClass;
         }
 
-        throw new \RuntimeException("No Exception class was never provided for this task.");
+        throw new \UnexpectedValueException("No Exception class was provided for this Node");
     }
 
     /**

--- a/src/Model/ExecutableNode.php
+++ b/src/Model/ExecutableNode.php
@@ -12,7 +12,7 @@ interface ExecutableNode
     /**
      * Returns the callback associated with this Task
      * If no callback was provided, an Exception is thrown
-     * @throws \RuntimeException
+     * @throws \UnexpectedValueException
      * @return callable
      */
     public function getCallback(): callable;

--- a/src/Model/ExecutableNodeTrait.php
+++ b/src/Model/ExecutableNodeTrait.php
@@ -13,7 +13,7 @@ trait ExecutableNodeTrait
     /**
      * Returns the callback associated with this Task
      * If no callback was provided, an Exception is thrown
-     * @throws \RuntimeException
+     * @throws \UnexpectedValueException
      * @return callable
      */
     public function getCallback(): callable
@@ -22,7 +22,7 @@ trait ExecutableNodeTrait
             return $this->callback;
         }
 
-        throw new \RuntimeException("Callback was never provided for this task");
+        throw new \UnexpectedValueException("No callback was provided for this Node");
     }
 
     /**

--- a/src/Model/Workflow.php
+++ b/src/Model/Workflow.php
@@ -18,7 +18,6 @@ class Workflow
      * Maintains reference for all the nodes, that composite this workflow.
      * @param WorkflowNode $node
      * @return WorkflowNode
-     * @throws \RuntimeException
      */
     public function add(WorkflowNode $node): WorkflowNode
     {

--- a/tests/Activity/TaskTest.php
+++ b/tests/Activity/TaskTest.php
@@ -23,7 +23,7 @@ class TaskTest extends TestCase
     {
         $task = new Task();
         $this->assertFalse($task->hasCallback());
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\UnexpectedValueException::class);
         $task->getCallback();
     }
 }

--- a/tests/Engine/SingleConnectionHandlerTest.php
+++ b/tests/Engine/SingleConnectionHandlerTest.php
@@ -5,6 +5,7 @@ namespace Phlow\Tests\Engine;
 use Phlow\Activity\Task;
 use Phlow\Engine\Exchange;
 use Phlow\Handler\SingleConnectionHandler;
+use Phlow\Handler\UnmatchedConditionException;
 use Phlow\Model\WorkflowConnection;
 use PHPUnit\Framework\TestCase;
 
@@ -26,7 +27,7 @@ class SingleConnectionHandlerTest extends TestCase
     public function testNoConnection()
     {
         $handler = new SingleConnectionHandler();
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(UnmatchedConditionException::class);
         $handler->handle(new Task(), new Exchange());
     }
 }

--- a/tests/Event/EndEventTest.php
+++ b/tests/Event/EndEventTest.php
@@ -4,6 +4,7 @@ namespace Phlow\Tests\Event;
 
 use Phlow\Engine\Exchange;
 use Phlow\Handler\SingleConnectionHandler;
+use Phlow\Handler\UnmatchedConditionException;
 use Phlow\Event\EndEvent;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class EndEventTest extends TestCase
         $task = new EndEvent();
         $handler = new SingleConnectionHandler();
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(UnmatchedConditionException::class);
         $handler->handle($task, new Exchange());
     }
 }

--- a/tests/Gateway/GatewayTest.php
+++ b/tests/Gateway/GatewayTest.php
@@ -6,6 +6,7 @@ use Phlow\Activity\Task;
 use Phlow\Engine\Exchange;
 use Phlow\Engine\ExpressionEngine;
 use Phlow\Handler\ConditionalConnectionHandler;
+use Phlow\Handler\UnmatchedConditionException;
 use Phlow\Gateway\ExclusiveGateway;
 use Phlow\Model\WorkflowConnection;
 use Phlow\Tests\Engine\DummyExpressionEngine;
@@ -27,7 +28,7 @@ class GatewayTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($nextTask, $handler->handle($gateway, $exchange));
 
         $exchange = new Exchange((object) ['num' => 50]);
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(UnmatchedConditionException::class);
         $this->assertEquals($nextTask, $handler->handle($gateway, $exchange));
 
         $exchange = new Exchange((object) ['num' => 500]);

--- a/tests/Workflow/WorkflowInstanceTest.php
+++ b/tests/Workflow/WorkflowInstanceTest.php
@@ -47,7 +47,7 @@ class WorkflowInstanceTest extends TestCase
     {
         $flow = new Workflow();
         $instance = new WorkflowInstance($flow, []);
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(InvalidStateException::class);
         $instance->advance();
     }
 
@@ -69,7 +69,7 @@ class WorkflowInstanceTest extends TestCase
     public function testCurrentBeforeExecution()
     {
         $workflow = $this->getPipeline();
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(InvalidStateException::class);
         $workflow->current();
     }
 
@@ -110,11 +110,11 @@ class WorkflowInstanceTest extends TestCase
             ->end();
         $instance = new WorkflowInstance($builder->getWorkflow(), ['num' => 10]);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(InvalidStateException::class);
         $instance->advance(2);
     }
 
-    public function testUnmatchedErrorHandling()
+    public function testUndefinedErrorHandling()
     {
         $builder = new WorkflowBuilder();
         $builder

--- a/tests/Workflow/WorkflowInstanceTest.php
+++ b/tests/Workflow/WorkflowInstanceTest.php
@@ -7,6 +7,7 @@ use Phlow\Event\EndEvent;
 use Phlow\Model\Workflow;
 use Phlow\Model\WorkflowBuilder;
 use Phlow\Engine\WorkflowInstance;
+use Phlow\Engine\InvalidStateException;
 use PHPUnit\Framework\TestCase;
 
 class WorkflowInstanceTest extends TestCase
@@ -56,7 +57,7 @@ class WorkflowInstanceTest extends TestCase
             ->start()
             ->end();
         $instance = new WorkflowInstance($builder->getWorkflow(), []);
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(InvalidStateException::class);
         $instance->advance(3);
 
         $this->assertTrue($instance->isCompleted());

--- a/tests/Workflow/WorkflowInstanceTest.php
+++ b/tests/Workflow/WorkflowInstanceTest.php
@@ -3,6 +3,7 @@
 namespace Phlow\Tests\Workflow;
 
 use Phlow\Activity\Task;
+use Phlow\Engine\UndefinedHandlerException;
 use Phlow\Event\EndEvent;
 use Phlow\Model\Workflow;
 use Phlow\Model\WorkflowBuilder;
@@ -133,7 +134,7 @@ class WorkflowInstanceTest extends TestCase
             ->end();
         $instance = new WorkflowInstance($builder->getWorkflow(), ['num' => 10]);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(UndefinedHandlerException::class);
         $instance->advance(2);
     }
 


### PR DESCRIPTION
There is an overuse of `RuntimeException`. The suggestion is to minimise the use of runtime exceptions by implementing custom extensions.