### PR TITLE
Switch to Tree structure

### DIFF
--- a/src/Activity/Task.php
+++ b/src/Activity/Task.php
@@ -16,4 +16,9 @@ class Task implements Activity, ExecutableNode
 {
     use WorkflowNodeTrait;
     use ExecutableNodeTrait;
+
+    public function isComposite(): bool
+    {
+        return false;
+    }
 }

--- a/src/Engine/ExecutionPath.php
+++ b/src/Engine/ExecutionPath.php
@@ -4,7 +4,7 @@ namespace Phlow\Engine;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Phlow\Model\WorkflowObject;
+use Phlow\Model\WorkflowObjectDeprecated;
 use Traversable;
 
 class ExecutionPath implements \IteratorAggregate, \Countable
@@ -24,10 +24,10 @@ class ExecutionPath implements \IteratorAggregate, \Countable
 
     /**
      * Adds a Workflow Node or Connection at the end of the execution path
-     * @param WorkflowObject $element
+     * @param WorkflowObjectDeprecated $element
      * @throws \InvalidArgumentException
      */
-    public function add(WorkflowObject $element)
+    public function add(WorkflowObjectDeprecated $element)
     {
         $this->sequence->add($element);
     }

--- a/src/Engine/WorkflowInstance.php
+++ b/src/Engine/WorkflowInstance.php
@@ -55,7 +55,6 @@ class WorkflowInstance implements LoggerAwareInterface
      * @var array Mapping between Workflow Nodes and Handlers
      */
     private $handlers = [
-        ErrorEvent::class => SingleConnectionHandler::class,
         Task::class => ExecutableHandler::class,
         ExclusiveGateway::class => ConditionalConnectionHandler::class
     ];

--- a/src/Engine/WorkflowInstance.php
+++ b/src/Engine/WorkflowInstance.php
@@ -148,13 +148,8 @@ class WorkflowInstance implements LoggerAwareInterface
 
             /** @var Handler $handler */
             $handler = new $handlerClass;
-            if ($handler instanceof ExecutionPathAwareInterface) {
-                $handler->setExecutionPath($this->executionPath);
-            }
-
             $connection = $handler->handle($this->current(), $this->exchange);
             $this->executionPath->add($connection);
-
 
             $this->logger->info(sprintf('Workflow execution completed for %s', $nodeClass));
         }

--- a/src/Engine/WorkflowInstance.php
+++ b/src/Engine/WorkflowInstance.php
@@ -154,9 +154,13 @@ class WorkflowInstance implements LoggerAwareInterface
 
             $connection = $handler->handle($this->current(), $this->exchange);
             $this->executionPath->add($connection);
-            $this->nextNode = $connection->getTarget();
+
 
             $this->logger->info(sprintf('Workflow execution completed for %s', $nodeClass));
+        }
+
+        if ($this->current()->hasNextStep()) {
+            $this->nextNode = $this->current()->getNextStep();
         }
     }
 

--- a/src/Engine/WorkflowInstance.php
+++ b/src/Engine/WorkflowInstance.php
@@ -55,7 +55,6 @@ class WorkflowInstance implements LoggerAwareInterface
      * @var array Mapping between Workflow Nodes and Handlers
      */
     private $handlers = [
-        StartEvent::class => SingleConnectionHandler::class,
         ErrorEvent::class => SingleConnectionHandler::class,
         Task::class => ExecutableHandler::class,
         ExclusiveGateway::class => ConditionalConnectionHandler::class
@@ -148,15 +147,14 @@ class WorkflowInstance implements LoggerAwareInterface
 
             /** @var Handler $handler */
             $handler = new $handlerClass;
-            $connection = $handler->handle($this->current(), $this->exchange);
-            $this->executionPath->add($connection);
-
-            $this->logger->info(sprintf('Workflow execution completed for %s', $nodeClass));
+            $handler->handle($this->current(), $this->exchange);
         }
 
         if ($this->current()->hasNextStep()) {
             $this->nextNode = $this->current()->getNextStep();
         }
+
+        $this->logger->info(sprintf('Workflow execution completed for %s', $nodeClass));
     }
 
     /**

--- a/src/Event/EndEvent.php
+++ b/src/Event/EndEvent.php
@@ -12,4 +12,9 @@ use Phlow\Model\WorkflowNodeTrait;
 class EndEvent implements Event
 {
     use WorkflowNodeTrait;
+
+    public function isComposite(): bool
+    {
+        return false;
+    }
 }

--- a/src/Event/ErrorEvent.php
+++ b/src/Event/ErrorEvent.php
@@ -15,4 +15,9 @@ class ErrorEvent implements Event, ExceptionHandlerNode
 {
     use WorkflowNodeTrait;
     use ExceptionHandlerTrait;
+
+    public function isComposite(): bool
+    {
+        return false;
+    }
 }

--- a/src/Event/StartEvent.php
+++ b/src/Event/StartEvent.php
@@ -12,4 +12,9 @@ use Phlow\Model\WorkflowNodeTrait;
 class StartEvent implements Event
 {
     use WorkflowNodeTrait;
+
+    public function isComposite(): bool
+    {
+        return false;
+    }
 }

--- a/src/Gateway/Branch.php
+++ b/src/Gateway/Branch.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phlow\Gateway;
+
+use Phlow\Model\WorkflowNode;
+use Phlow\Model\WorkflowNodeTrait;
+
+class Branch implements WorkflowNode
+{
+    use WorkflowNodeTrait;
+
+    private $condition;
+
+    public function __construct($condition = 'true')
+    {
+        $this->condition = $condition;
+    }
+
+    public function isComposite(): bool
+    {
+        return true;
+    }
+
+    public function getCondition()
+    {
+        return $this->condition;
+    }
+
+    public function isConditional()
+    {
+        return !empty($this->condition);
+    }
+}

--- a/src/Gateway/ExclusiveGateway.php
+++ b/src/Gateway/ExclusiveGateway.php
@@ -12,4 +12,9 @@ use Phlow\Model\WorkflowNodeTrait;
 class ExclusiveGateway implements Gateway
 {
     use WorkflowNodeTrait;
+
+    public function isComposite(): bool
+    {
+        return true;
+    }
 }

--- a/src/Model/Workflow.php
+++ b/src/Model/Workflow.php
@@ -6,72 +6,12 @@ namespace Phlow\Model;
  * Class Workflow
  * @package Phlow\Workflow
  */
-class Workflow
+class Workflow /* implements WorkflowStep */
 {
-    /**
-     * @var array Unordered list of the nodes, that composite this workflow.
-     */
-    private $nodes = [];
+    use WorkflowStepTrait;
 
-    /**
-     * Adds the provided node in the list of nodes.
-     * Maintains reference for all the nodes, that composite this workflow.
-     * @param WorkflowNode $node
-     * @return WorkflowNode
-     */
-    public function add(WorkflowNode $node): WorkflowNode
+    public function isComposite(): bool
     {
-        $this->nodes[] = $node;
-        return $node;
-    }
-
-    /**
-     * Adds the provided the nodes in this workflow
-     * @param WorkflowNode ...$nodes
-     * @return void
-     */
-    public function addAll(WorkflowNode ...$nodes): void
-    {
-        foreach ($nodes as $node) {
-            $this->add($node);
-        }
-    }
-
-    /**
-     * Removes the provided node from the list.
-     * @param WorkflowNode $node
-     * @return void
-     * @throws NotFoundException
-     */
-    public function remove(WorkflowNode $node): void
-    {
-        $key = array_search($node, $this->nodes, true);
-        if ($key === false) {
-            throw new NotFoundException("Node was not found");
-        }
-
-        array_splice($this->nodes, $key, 1);
-    }
-
-    /**
-     * Returns all the nodes currently associated with this workflow, in no particular order
-     * @param callable|null $filter
-     * @return iterable
-     */
-    public function getAll(callable $filter = null): iterable
-    {
-        return ($filter) ? array_values(array_filter($this->nodes, $filter)) : $this->nodes;
-    }
-
-    /**
-     * Returns all nodes that are instances of the specified class
-     * @param $class
-     * @return iterable
-     */
-    public function getAllByClass($class): iterable
-    {
-        return $this->getAll(function ($node) use ($class) {
-            return $node instanceof $class;
-        });
+        return true;
     }
 }

--- a/src/Model/WorkflowConnection.php
+++ b/src/Model/WorkflowConnection.php
@@ -2,7 +2,7 @@
 
 namespace Phlow\Model;
 
-class WorkflowConnection implements WorkflowObject
+class WorkflowConnection implements WorkflowObjectDeprecated
 {
     private $source;
     private $target;

--- a/src/Model/WorkflowConnection.php
+++ b/src/Model/WorkflowConnection.php
@@ -13,6 +13,8 @@ class WorkflowConnection implements WorkflowObjectDeprecated
         $source->addOutgoingConnection($this);
         $target->addIncomingConnection($this);
 
+        $source->setNextStep($target);
+
         $this->source = $source;
         $this->target = $target;
         $this->condition = $condition;

--- a/src/Model/WorkflowNode.php
+++ b/src/Model/WorkflowNode.php
@@ -5,7 +5,7 @@ namespace Phlow\Model;
  * Interface WorkflowNode
  * @package Phlow\Workflow
  */
-interface WorkflowNode extends WorkflowObject
+interface WorkflowNode extends WorkflowObjectDeprecated
 {
     public function addOutgoingConnection(WorkflowConnection $connection): void;
 

--- a/src/Model/WorkflowNode.php
+++ b/src/Model/WorkflowNode.php
@@ -5,7 +5,7 @@ namespace Phlow\Model;
  * Interface WorkflowNode
  * @package Phlow\Workflow
  */
-interface WorkflowNode extends WorkflowObjectDeprecated
+interface WorkflowNode extends WorkflowObjectDeprecated, WorkflowStep
 {
     public function addOutgoingConnection(WorkflowConnection $connection): void;
 

--- a/src/Model/WorkflowNodeTrait.php
+++ b/src/Model/WorkflowNodeTrait.php
@@ -4,6 +4,8 @@ namespace Phlow\Model;
 
 trait WorkflowNodeTrait
 {
+    use WorkflowStepTrait;
+
     private $incomingConnections = [];
 
     private $outgoingConnections = [];

--- a/src/Model/WorkflowObject.php
+++ b/src/Model/WorkflowObject.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Phlow\Model;
-
-interface WorkflowObject extends \RecursiveIterator, \Countable
-{
-}

--- a/src/Model/WorkflowObject.php
+++ b/src/Model/WorkflowObject.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Phlow\Model;
+
+interface WorkflowObject extends \RecursiveIterator, \Countable
+{
+}

--- a/src/Model/WorkflowObjectDeprecated.php
+++ b/src/Model/WorkflowObjectDeprecated.php
@@ -2,6 +2,6 @@
 
 namespace Phlow\Model;
 
-interface WorkflowObject
+interface WorkflowObjectDeprecated
 {
 }

--- a/src/Model/WorkflowStep.php
+++ b/src/Model/WorkflowStep.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Phlow\Model;
+
+interface WorkflowStep
+{
+    public function isComposite(): bool;
+    public function add(WorkflowStep $step): void;
+    public function addAll(WorkflowStep ...$steps): void;
+    public function remove(WorkflowStep $step): void;
+    public function isEmpty(): bool;
+    public function getAll(callable $filter = null): iterable;
+    public function getAllByClass($class): iterable;
+}

--- a/src/Model/WorkflowStep.php
+++ b/src/Model/WorkflowStep.php
@@ -11,4 +11,10 @@ interface WorkflowStep
     public function isEmpty(): bool;
     public function getAll(callable $filter = null): iterable;
     public function getAllByClass($class): iterable;
+    public function first(): WorkflowStep;
+    public function last(): WorkflowStep;
+
+    public function getNextStep(): WorkflowStep;
+    public function setNextStep(WorkflowStep $step): void;
+    public function hasNextStep(): bool;
 }

--- a/src/Model/WorkflowStepTrait.php
+++ b/src/Model/WorkflowStepTrait.php
@@ -10,6 +10,11 @@ trait WorkflowStepTrait
     private $steps = [];
 
     /**
+     * @var WorkflowStep
+     */
+    private $nextStep;
+
+    /**
      * Adds the provided step at the end of the collection.
      * @param WorkflowStep $step
      * @throws \BadMethodCallException
@@ -52,7 +57,7 @@ trait WorkflowStepTrait
         if ($key === false) {
             throw new NotFoundException("Step was not found");
         }
-        
+
         array_splice($this->steps, $key, 1);
     }
 
@@ -85,5 +90,59 @@ trait WorkflowStepTrait
         return $this->getAll(function ($step) use ($class) {
             return $step instanceof $class;
         });
+    }
+
+    /**
+     * Returns the first step
+     * @return WorkflowStep
+     * @throws NotFoundException
+     */
+    public function first(): WorkflowStep
+    {
+        if ($this->isEmpty()) {
+            throw new NotFoundException();
+        }
+
+        return $this->steps[0];
+    }
+
+    /**
+     * Returns the last step
+     * @return WorkflowStep
+     * @throws NotFoundException
+     */
+    public function last(): WorkflowStep
+    {
+        if ($this->isEmpty()) {
+            throw new NotFoundException();
+        }
+
+        $last = end($this->steps);
+        reset($array);
+        return $last;
+    }
+
+    /**
+     * @return WorkflowStep
+     */
+    public function getNextStep(): WorkflowStep
+    {
+        return $this->nextStep;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasNextStep(): bool
+    {
+        return !empty($this->nextStep);
+    }
+
+    /**
+     * @param WorkflowStep $nextStep
+     */
+    public function setNextStep(WorkflowStep $nextStep): void
+    {
+        $this->nextStep = $nextStep;
     }
 }

--- a/src/Model/WorkflowStepTrait.php
+++ b/src/Model/WorkflowStepTrait.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Phlow\Model;
+
+trait WorkflowStepTrait
+{
+    /**
+     * @var array
+     */
+    private $steps = [];
+
+    /**
+     * Adds the provided step at the end of the collection.
+     * @param WorkflowStep $step
+     * @throws \BadMethodCallException
+     */
+    public function add(WorkflowStep $step): void
+    {
+        if (!$this->isComposite()) {
+            throw new \BadMethodCallException();
+        }
+
+        $this->steps[] = $step;
+    }
+
+    /**
+     * Adds the provided step at the end of the collection.
+     * @param WorkflowStep ...$steps
+     * @return void
+     */
+    public function addAll(WorkflowStep ...$steps): void
+    {
+        foreach ($steps as $step) {
+            $this->add($step);
+        }
+    }
+
+    /**
+     * Removes the specified step from the collection, if it is found.
+     * @param WorkflowStep $step
+     * @return void
+     * @throws NotFoundException
+     * @throws \BadMethodCallException
+     */
+    public function remove(WorkflowStep $step): void
+    {
+        if (!$this->isComposite()) {
+            throw new \BadMethodCallException();
+        }
+
+        $key = array_search($step, $this->steps, true);
+        if ($key === false) {
+            throw new NotFoundException("Step was not found");
+        }
+        
+        array_splice($this->steps, $key, 1);
+    }
+
+    /**
+     * Checks whether this step is empty (contains no sub-steps).
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->steps);
+    }
+
+    /**
+     * Returns all the sub-steps currently associated with this Step, in no particular order
+     * @param callable|null $filter
+     * @return iterable
+     */
+    public function getAll(callable $filter = null): iterable
+    {
+        return ($filter) ? array_values(array_filter($this->steps, $filter)) : $this->steps;
+    }
+
+    /**
+     * Returns all steps that are instances of the specified class
+     * @param $class
+     * @return iterable
+     */
+    public function getAllByClass($class): iterable
+    {
+        return $this->getAll(function ($step) use ($class) {
+            return $step instanceof $class;
+        });
+    }
+}

--- a/tests/Workflow/WorkflowInstanceTest.php
+++ b/tests/Workflow/WorkflowInstanceTest.php
@@ -159,11 +159,10 @@ class WorkflowInstanceTest extends TestCase
         $instance->execute();
 
         // 1. Workflow execution initiated
-        // 2/4/6 StartEvent/Task/Task reached
-        // 3/5/7. StartEvent/Task/Task executed
-        // 8. Workflow execution reached Phlow\Event\EndEvent
-        // 9. Workflow execution completed
-        $this->assertEquals(9, count($logger->getAllRecords()));
+        // 2/4/6/8 StartEvent/Task/Task/EndEvent reached
+        // 3/5/7/9 StartEvent/Task/Task/EndEvent executed
+        // 10. Workflow execution completed
+        $this->assertEquals(10, count($logger->getAllRecords()));
     }
 
     public function testExecutionPath()
@@ -175,11 +174,10 @@ class WorkflowInstanceTest extends TestCase
         $instance = new WorkflowInstance($builder->getWorkflow(), []);
         $instance->execute();
 
-        $this->assertEquals(3, count($instance->getExecutionPath()));
+        $this->assertEquals(2, count($instance->getExecutionPath()));
         $path = iterator_to_array($instance->getExecutionPath());
         $this->assertInstanceOf(StartEvent::class, $path[0]);
-        $this->assertInstanceOf(WorkflowConnection::class, $path[1]);
-        $this->assertInstanceOf(EndEvent::class, $path[2]);
+        $this->assertInstanceOf(EndEvent::class, $path[1]);
     }
 
     public function testGetWorkflow()

--- a/tests/Workflow/WorkflowInstanceTest.php
+++ b/tests/Workflow/WorkflowInstanceTest.php
@@ -6,6 +6,7 @@ use Phlow\Activity\Task;
 use Phlow\Engine\UndefinedHandlerException;
 use Phlow\Event\EndEvent;
 use Phlow\Event\StartEvent;
+use Phlow\Model\NotFoundException;
 use Phlow\Model\Workflow;
 use Phlow\Model\WorkflowBuilder;
 use Phlow\Engine\WorkflowInstance;
@@ -20,8 +21,8 @@ class WorkflowInstanceTest extends TestCase
     {
         $workflow = $this->getPipeline();
         $workflow->advance(1);
-        $this->assertTrue($workflow->current() instanceof StartEvent);
-        $this->assertTrue($workflow->next() instanceof Task);
+        $this->assertInstanceOf(StartEvent::class, $workflow->current());
+        $this->assertInstanceOf(Task::class, $workflow->next());
         $this->assertTrue($workflow->inProgress());
         $this->assertFalse($workflow->isCompleted());
     }


### PR DESCRIPTION
The aim of this PR is to switch workflow structure from Graph to Ordered Lists. The main reason is to simplify the structure and avoid complex setups.

In particular:
* WorkflowNode will be renamed to WorkflowStep. A workflow is a list of Steps
* Any WorkflowStep can have other Sub-steps
* The execution order is defined by each WorkflowStep (Ordered List) rather by the edges between WorkflowNodes
* Conditions (i.e. ExclusiveGateway) can represented as a new type of step
* Lists can be iterated using build-in Iterators